### PR TITLE
Sort table results by ascending file size

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -151,8 +151,7 @@ pub fn print(duplicates: DashMap<String, Vec<File>>, opts: &Params) {
             // we extract the file size of the first file in the group
             let size =
                 f.1.first()
-                    .and_then(|ff| Some(&ff.path))
-                    .and_then(|p| fs::metadata(p).ok())
+                    .and_then(|ff| fs::metadata(&ff.path).ok())
                     .and_then(|m| Some(m.len()));
             (f.0, f.1, size)
         })

--- a/src/output.rs
+++ b/src/output.rs
@@ -152,7 +152,8 @@ pub fn print(duplicates: DashMap<String, Vec<File>>, opts: &Params) {
             let size =
                 f.1.first()
                     .and_then(|ff| fs::metadata(&ff.path).ok())
-                    .and_then(|m| Some(m.len()));
+                    .and_then(|m| Some(m.len()))
+                    .unwrap_or_default();
             (f.0, f.1, size)
         })
         .sorted_unstable_by_key(|f| f.2) // sort by ascending size
@@ -164,7 +165,7 @@ pub fn print(duplicates: DashMap<String, Vec<File>>, opts: &Params) {
                     format_path(&file.path, opts).unwrap_or_default().blue(),
                     // since all files should logically have the same size,
                     // we can print the pre-computed size of the first element in the group
-                    format!("{:>12}", format_size(size.unwrap_or_default(), DECIMAL)).red(),
+                    format!("{:>12}", format_size(size, DECIMAL)).red(),
                     modified_time(&file.path).unwrap_or_default().yellow()
                 ]);
             });

--- a/src/output.rs
+++ b/src/output.rs
@@ -128,6 +128,9 @@ pub fn interactive(duplicates: DashMap<String, Vec<File>>, opts: &Params) {
     duplicates
         .clone()
         .into_iter()
+        .sorted_unstable_by_key(|f| {
+            -(f.1.first().and_then(|ff| ff.size).unwrap_or_default() as i64)
+        })
         .enumerate()
         .for_each(|(gindex, (_, group))| {
             let mut itable = Table::new();

--- a/src/output.rs
+++ b/src/output.rs
@@ -130,7 +130,7 @@ pub fn interactive(duplicates: DashMap<String, Vec<File>>, opts: &Params) {
         .into_iter()
         .sorted_unstable_by_key(|f| {
             -(f.1.first().and_then(|ff| ff.size).unwrap_or_default() as i64)
-        })
+        }) // sort by descending file size in interactive mode
         .enumerate()
         .for_each(|(gindex, (_, group))| {
             let mut itable = Table::new();


### PR DESCRIPTION
This change makes the result table sorted by ascending size, allowing the user to immediately see the largest file at the bottom of the (potentially large) output.